### PR TITLE
Implement MVP token counting backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+
+# Virtual environments
+.venv/
+venv/
+
+# Editor settings
+*.swp
+.DS_Store

--- a/Readme
+++ b/Readme
@@ -1,1 +1,149 @@
-你好
+# 大模型 Token 计算器设计方案
+
+## 1. 项目目标
+- 为用户提供一个简单、快速的方式来估算文本在不同大模型下的 token 数量。
+- 支持 OpenAI GPT 系列（gpt-3.5、gpt-4、gpt-4o 等）、阿里 Qwen 系列、DeepSeek 系列等常见模型。
+- 支持根据模型不同的上下文长度限制给出超限提醒，并预估费用（若有价格信息）。
+
+## 2. 核心需求与功能列表
+1. **文本输入**：支持多语言长文本粘贴，实时统计字符数、行数。
+2. **模型选择**：
+   - 预置模型列表（按厂商分组），提供搜索/收藏功能。
+   - 显示模型上下文长度、token 价格等元信息。
+3. **Token 计算**：
+   - 根据所选模型对应的分词器计算 token 数。
+   - 对于不在列表内的模型允许用户选择相近的分词规则或上传自定义 vocab。
+4. **结果展示**：
+   - 展示 token 数、已用上下文百分比、估算费用。
+   - 若超出上下文长度，给出拆分建议或提示。
+5. **历史记录与导出**：允许用户保存、导出计算结果。
+6. **开发者模式**：提供 API，支持第三方调用。
+
+## 3. Tokenizer 设计
+| 模型系列 | 分词器方案 | 说明 |
+| --- | --- | --- |
+| GPT 系列 | 使用 [tiktoken](https://github.com/openai/tiktoken) 或 OpenAI 提供的官方编码器。 | 需要预先下载模型对应的 encoding（如 `cl100k_base` 等）。 |
+| DeepSeek 系列 | 使用官方开源的 BPE vocab（可通过 `sentencepiece` 或 `tokenizers` 加载）。 | DeepSeek 官方仓库提供 `tokenizer.model`，可用 `sentencepiece` 解码。 |
+| Qwen 系列 | 使用阿里提供的 tiktoken 兼容版或开源的 `tiktoken_qwen`。 | 需根据模型版本选择对应词表。 |
+| 自定义模型 | 支持上传 BPE/ sentencepiece 词表，使用 HuggingFace `tokenizers` 动态加载。 | 允许用户选择分词模式（BPE、Unigram、WordPiece 等）。 |
+
+> **实现建议**：将 tokenizer 抽象为统一接口 `TokenizerAdapter`，封装 `encode(text) -> tokens` 与 `decode(tokens)`。
+
+## 4. 系统架构
+```
+┌──────────────────────────────────────────────────────┐
+│                      前端 Web                        │
+│ ┌─────────────┐ ┌─────────────┐ ┌──────────────────┐ │
+│ │ 文本输入区   │ │ 模型选择面板 │ │ 结果展示/历史区    │ │
+│ └─────────────┘ └─────────────┘ └──────────────────┘ │
+└────────────┬────────────────────────────────────────┘
+             │HTTPS/REST + WebSocket (用于实时反馈)
+┌────────────┴────────────────────────────────────────┐
+│                      后端服务                        │
+│ ┌──────────────────────────────────────────────────┐ │
+│ │ Tokenizer Service                                │ │
+│ │  - 统一适配层                                     │ │
+│ │  - 模型元信息缓存/加载                             │ │
+│ ├──────────────────────────────────────────────────┤ │
+│ │ Metadata Service                                  │ │
+│ │  - 模型配置（上下文长度、价格）                    │ │
+│ │  - 更新任务（定时同步官网/开源项目数据）           │ │
+│ ├──────────────────────────────────────────────────┤ │
+│ │ API Gateway / GraphQL 层                          │ │
+│ └──────────────────────────────────────────────────┘ │
+│               ↕                                    ↕  │
+│         Redis/Memcached (缓存)      PostgreSQL/SQLite │
+└──────────────────────────────────────────────────────┘
+```
+
+## 5. 前端设计要点
+- **技术栈**：React + TypeScript + TailwindCSS，或使用 Vue + Element Plus。
+- **实时反馈**：文本输入触发 debounced 请求（例如 300ms）到后端获取 token 数；对于短文本可直接在前端本地计算（加载 wasm/tokenizer）。
+- **模型列表**：支持分组折叠、搜索、收藏、最近使用。
+- **辅助功能**：
+  - 一键复制 token 结果。
+  - 粘贴 Markdown/代码自动保留格式。
+  - 支持黑暗模式。
+
+## 6. 后端设计要点
+- **技术栈**：Python（FastAPI）或 Node.js（NestJS）。
+- **Tokenizer Adapter**：
+  - 抽象类定义 `name`, `max_context`, `calculate_tokens(text)`。
+  - 针对不同模型加载对应词表，考虑热加载与缓存。
+- **性能优化**：
+  - 长文本使用异步任务，返回任务 ID，完成后推送结果。
+  - 常用模型词表缓存到内存，减少磁盘读取。
+- **可扩展性**：
+  - Model Metadata 存储配置项（上下文长度、默认价格、发布信息等）。
+  - 新增模型只需更新配置与词表即可。
+
+## 7. Token 计算流程
+1. 用户粘贴文本并选择模型。
+2. 前端发送 `POST /api/tokenize`，包含文本、模型标识。
+3. 后端根据模型标识加载对应 Tokenizer Adapter。
+4. 调用 `adapter.encode(text)` 返回 token 序列。
+5. 计算 token 数、上下文占比、费用估算，响应给前端。
+6. 记录请求日志（匿名化）用于使用统计。
+
+## 8. 扩展与增值功能
+- **批量模式**：上传文件（txt、md、docx），按段落或文件进行统计。
+- **Prompt 模版库**：结合常见 Prompt 模板计算 token 使用量。
+- **团队协作**：成员共享历史记录、设置统一计费标准。
+- **浏览器插件/VSCode 插件**：直接在编辑器中获取 token 数。
+
+## 9. 安全与隐私
+- 对用户粘贴文本进行本地加密传输，后端默认不持久化原始文本。
+- 提供本地部署模式，确保敏感数据不出内网。
+
+## 10. 部署方案
+- 使用 Docker Compose 部署（web、api、redis、db）。
+- 支持云服务（Vercel/Netlify + Render/Fly.io）或企业内网 Kubernetes。
+
+## 11. 迭代路线图
+1. **MVP**：支持 GPT/DeepSeek/Qwen 三大系列核心模型的 token 计算，前端实时展示。
+2. **增强版**：加入费用估算、历史记录、批量导入。
+3. **专业版**：提供团队协作、API 接口、插件生态。
+
+---
+如需进一步的技术细节或原型设计，可以在此基础上继续细化。
+
+## 12. 代码实现概述
+- 使用纯标准库实现，可在无第三方依赖的环境运行。
+- 核心模块划分：
+  - `app/config.py`：加载模型与分词器配置（默认 `app/resources/model_registry.json`）。
+  - `app/tokenizers/`：实现可配置的正则分词器与字节分词器，并提供注册表工厂。
+  - `app/services/token_service.py`：聚合模型元数据与分词器，对外提供计算接口。
+  - `app/server.py`：基于 `http.server` 提供 `/models` 与 `/tokenize` HTTP API。
+  - `app/__main__.py`：命令行入口，支持列出模型、文件/文本计数以及启动服务。
+- 默认内置 GPT、DeepSeek、Qwen 三个系列的模型示例，便于快速扩展：
+  - GPT 使用折叠空白的正则分词方案。
+  - DeepSeek 在计算中保留空白（折叠为 `<ws>`）。
+  - Qwen 保留原始空白差异，便于更精细的统计。
+
+## 13. 使用方式
+### 13.1 命令行
+```bash
+python -m app models               # 查看支持的模型列表
+python -m app count --model gpt-4o-mini --text "测试文本"
+python -m app count --model qwen-2-7b --file sample.txt
+```
+- 可通过 `--registry /path/to/model_registry.json` 指定自定义配置。
+
+### 13.2 HTTP 服务
+```bash
+python -m app serve --host 0.0.0.0 --port 8080
+```
+- `GET /models`：返回模型列表与元信息。
+- `POST /tokenize`：请求体 `{ "model": "gpt-4o-mini", "text": "..." }`，返回 token 数、上下文占用、价格估算等。
+
+### 13.3 扩展模型
+1. 在 `app/resources/model_registry.json` 中新增模型配置，或通过 `--registry` 传入外部 JSON 文件。
+2. 配置项中的 `tokenizer.type` 当前支持 `regex`（可配置正则规则）与 `byte`（按 UTF-8 字节计数）。
+3. 若后续需要接入真实官方 tokenizer，可在 `app/tokenizers` 中新增适配器并在注册表注册即可复用现有服务逻辑。
+
+## 14. 测试
+- 使用 `unittest` 验证分词器、服务层及 CLI 行为。
+- 运行方法：
+```bash
+python -m unittest discover -s tests
+```

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,11 @@
+"""Core package for the LLM token counter service."""
+
+from .config import load_registry
+from .services.token_service import TokenService
+from .tokenizers.registry import TokenizerRegistry
+
+__all__ = [
+    "load_registry",
+    "TokenService",
+    "TokenizerRegistry",
+]

--- a/app/__main__.py
+++ b/app/__main__.py
@@ -1,0 +1,73 @@
+"""Command line entry-point for the token counter application."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from .config import load_registry
+from .server import serve
+from .services.token_service import TokenService
+from .tokenizers.registry import TokenizerRegistry
+
+
+def _create_service(registry_path: str | None = None) -> TokenService:
+    models = load_registry(Path(registry_path) if registry_path else None)
+    registry = TokenizerRegistry()
+    return TokenService(models=models, registry=registry)
+
+
+def _cmd_list_models(args) -> int:
+    service = _create_service(args.registry)
+    payload = {"models": service.list_models()}
+    json.dump(payload, sys.stdout, ensure_ascii=False, indent=2)
+    sys.stdout.write("\n")
+    return 0
+
+
+def _cmd_count(args) -> int:
+    service = _create_service(args.registry)
+    text = args.text
+    if args.file:
+        text = Path(args.file).read_text(encoding="utf-8")
+    result = service.calculate(model_id=args.model, text=text)
+    json.dump(result, sys.stdout, ensure_ascii=False, indent=2)
+    sys.stdout.write("\n")
+    return 0
+
+
+def _cmd_serve(args) -> int:
+    host = args.host
+    port = int(args.port)
+    serve(host=host, port=port)
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="LLM token counter utilities")
+    parser.add_argument("--registry", help="Path to custom model registry JSON", default=None)
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    sp_list = subparsers.add_parser("models", help="List supported models")
+    sp_list.set_defaults(func=_cmd_list_models)
+
+    sp_count = subparsers.add_parser("count", help="Count tokens for input text")
+    sp_count.add_argument("--model", required=True, help="Model identifier")
+    sp_count.add_argument("--text", help="Text to tokenize", default="")
+    sp_count.add_argument("--file", help="Path to file with text content")
+    sp_count.set_defaults(func=_cmd_count)
+
+    sp_serve = subparsers.add_parser("serve", help="Start HTTP API server")
+    sp_serve.add_argument("--host", default="127.0.0.1")
+    sp_serve.add_argument("--port", default="8000")
+    sp_serve.set_defaults(func=_cmd_serve)
+
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entrypoint
+    raise SystemExit(main())

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,65 @@
+"""Utilities for loading model configuration."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterable, List
+
+from .models import ModelSpec, Pricing, TokenizerSpec
+
+_DEFAULT_REGISTRY_PATH = Path(__file__).resolve().parent / "resources" / "model_registry.json"
+
+
+def _parse_pricing(data):
+    if data is None:
+        return None
+    currency = data.get("currency", "USD")
+    input_price = data.get("input_per_1k")
+    output_price = data.get("output_per_1k")
+    return Pricing(currency=currency, input_per_1k=input_price, output_per_1k=output_price)
+
+
+def _parse_tokenizer(spec):
+    if not isinstance(spec, dict) or "type" not in spec:
+        raise ValueError("Tokenizer spec must define a 'type'.")
+    type_name = spec["type"].strip().lower()
+    options = spec.get("options", {})
+    if not isinstance(options, dict):
+        raise ValueError("Tokenizer options must be a mapping.")
+    return TokenizerSpec(type=type_name, options=options)
+
+
+def load_registry(path: Path | None = None) -> List[ModelSpec]:
+    """Load model specifications from a JSON file."""
+
+    target = Path(path) if path else _DEFAULT_REGISTRY_PATH
+    if not target.exists():
+        raise FileNotFoundError(f"Model registry file not found: {target}")
+
+    with target.open("r", encoding="utf-8") as stream:
+        raw_data = json.load(stream)
+
+    if not isinstance(raw_data, Iterable):
+        raise ValueError("Model registry must be a list of models.")
+
+    models: List[ModelSpec] = []
+    for item in raw_data:
+        model_id = item.get("id")
+        if not model_id:
+            raise ValueError("Model entry must include an 'id'.")
+        tokenizer_spec = _parse_tokenizer(item.get("tokenizer"))
+        pricing = _parse_pricing(item.get("pricing"))
+        models.append(
+            ModelSpec(
+                model_id=model_id,
+                display_name=item.get("display_name", model_id),
+                family=item.get("family", "unknown"),
+                provider=item.get("provider", "unknown"),
+                max_context=int(item.get("max_context", 0)),
+                tokenizer=tokenizer_spec,
+                description=item.get("description"),
+                pricing=pricing,
+            )
+        )
+    return models

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,64 @@
+"""Dataclasses describing model and tokenizer configuration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+
+@dataclass(frozen=True)
+class Pricing:
+    """Pricing information for a model."""
+
+    currency: str = "USD"
+    input_per_1k: Optional[float] = None
+    output_per_1k: Optional[float] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a serialisable representation."""
+
+        return {
+            "currency": self.currency,
+            "input_per_1k": self.input_per_1k,
+            "output_per_1k": self.output_per_1k,
+        }
+
+
+@dataclass(frozen=True)
+class TokenizerSpec:
+    """Description of a tokenizer implementation."""
+
+    type: str
+    options: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"type": self.type, "options": dict(self.options)}
+
+
+@dataclass(frozen=True)
+class ModelSpec:
+    """Metadata describing a supported large language model."""
+
+    model_id: str
+    display_name: str
+    family: str
+    provider: str
+    max_context: int
+    tokenizer: TokenizerSpec
+    description: Optional[str] = None
+    pricing: Optional[Pricing] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        data = {
+            "id": self.model_id,
+            "display_name": self.display_name,
+            "family": self.family,
+            "provider": self.provider,
+            "max_context": self.max_context,
+            "tokenizer": self.tokenizer.to_dict(),
+        }
+        if self.description:
+            data["description"] = self.description
+        if self.pricing:
+            data["pricing"] = self.pricing.to_dict()
+        return data

--- a/app/resources/model_registry.json
+++ b/app/resources/model_registry.json
@@ -1,0 +1,57 @@
+[
+  {
+    "id": "gpt-4o-mini",
+    "display_name": "GPT-4o Mini",
+    "family": "gpt",
+    "provider": "OpenAI",
+    "description": "Lightweight GPT model suitable for quick prompt estimation.",
+    "max_context": 128000,
+    "tokenizer": {
+      "type": "regex",
+      "options": {
+        "name": "gpt-regex",
+        "keep_whitespace": false,
+        "collapse_whitespace": true
+      }
+    },
+    "pricing": {
+      "currency": "USD",
+      "input_per_1k": 0.00015,
+      "output_per_1k": 0.0006
+    }
+  },
+  {
+    "id": "deepseek-chat",
+    "display_name": "DeepSeek Chat",
+    "family": "deepseek",
+    "provider": "DeepSeek",
+    "description": "Community edition DeepSeek conversational model.",
+    "max_context": 65536,
+    "tokenizer": {
+      "type": "regex",
+      "options": {
+        "name": "deepseek-regex",
+        "keep_whitespace": true,
+        "collapse_whitespace": true
+      }
+    },
+    "pricing": null
+  },
+  {
+    "id": "qwen-2-7b",
+    "display_name": "Qwen 2 7B",
+    "family": "qwen",
+    "provider": "Alibaba Cloud",
+    "description": "Open Qwen 2 7B model",
+    "max_context": 131072,
+    "tokenizer": {
+      "type": "regex",
+      "options": {
+        "name": "qwen-regex",
+        "keep_whitespace": false,
+        "collapse_whitespace": false
+      }
+    },
+    "pricing": null
+  }
+]

--- a/app/server.py
+++ b/app/server.py
@@ -1,0 +1,72 @@
+"""Minimal HTTP server exposing the token counting service."""
+
+from __future__ import annotations
+
+import json
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Callable
+
+from .config import load_registry
+from .services.token_service import ModelNotFoundError, TokenService
+from .tokenizers.registry import TokenizerRegistry
+
+
+def _build_handler(service: TokenService) -> Callable[..., BaseHTTPRequestHandler]:
+    class TokenCounterHandler(BaseHTTPRequestHandler):
+        def _send_json(self, status: HTTPStatus, payload):
+            body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+            self.send_response(status.value)
+            self.send_header("Content-Type", "application/json; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, format, *args):  # pragma: no cover - quieter tests
+            return
+
+        def do_GET(self):  # noqa: N802 - required by BaseHTTPRequestHandler
+            if self.path.rstrip("/") == "/models":
+                self._send_json(HTTPStatus.OK, {"models": service.list_models()})
+            else:
+                self._send_json(HTTPStatus.NOT_FOUND, {"error": "unknown endpoint"})
+
+        def do_POST(self):  # noqa: N802 - required by BaseHTTPRequestHandler
+            if self.path.rstrip("/") != "/tokenize":
+                self._send_json(HTTPStatus.NOT_FOUND, {"error": "unknown endpoint"})
+                return
+
+            content_length = int(self.headers.get("Content-Length", "0"))
+            raw_body = self.rfile.read(content_length) if content_length else b""
+            try:
+                payload = json.loads(raw_body.decode("utf-8")) if raw_body else {}
+            except json.JSONDecodeError:
+                self._send_json(HTTPStatus.BAD_REQUEST, {"error": "invalid json"})
+                return
+
+            model_id = payload.get("model") or payload.get("model_id")
+            text = payload.get("text", "")
+            if not model_id:
+                self._send_json(HTTPStatus.BAD_REQUEST, {"error": "'model' is required"})
+                return
+
+            try:
+                result = service.calculate(model_id=model_id, text=text)
+            except ModelNotFoundError:
+                self._send_json(HTTPStatus.NOT_FOUND, {"error": f"unknown model '{model_id}'"})
+                return
+
+            self._send_json(HTTPStatus.OK, result)
+
+    return TokenCounterHandler
+
+
+def serve(host: str = "127.0.0.1", port: int = 8000) -> None:
+    """Start a blocking HTTP server."""
+
+    registry = TokenizerRegistry()
+    models = load_registry()
+    service = TokenService(models=models, registry=registry)
+    handler = _build_handler(service)
+    with HTTPServer((host, port), handler) as httpd:
+        httpd.serve_forever()

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,0 +1,5 @@
+"""Service layer for the LLM token counter."""
+
+from .token_service import ModelNotFoundError, TokenService
+
+__all__ = ["ModelNotFoundError", "TokenService"]

--- a/app/services/token_service.py
+++ b/app/services/token_service.py
@@ -1,0 +1,55 @@
+"""Token counting service that orchestrates tokenizers and models."""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, List
+
+from ..models import ModelSpec
+from ..tokenizers.registry import TokenizerRegistry, get_tokenizer_for_model
+
+
+class ModelNotFoundError(KeyError):
+    """Raised when a requested model is not registered."""
+
+
+class TokenService:
+    """High level API used by both CLI and HTTP interfaces."""
+
+    def __init__(self, models: Iterable[ModelSpec], registry: TokenizerRegistry | None = None) -> None:
+        self._models: Dict[str, ModelSpec] = {model.model_id: model for model in models}
+        self._registry = registry or TokenizerRegistry()
+
+    def list_models(self) -> List[Dict[str, object]]:
+        return [model.to_dict() for model in self._models.values()]
+
+    def get_model(self, model_id: str) -> ModelSpec:
+        try:
+            return self._models[model_id]
+        except KeyError as exc:  # pragma: no cover - defensive
+            raise ModelNotFoundError(model_id) from exc
+
+    def calculate(self, model_id: str, text: str) -> Dict[str, object]:
+        model = self.get_model(model_id)
+        tokenizer = get_tokenizer_for_model(model, self._registry)
+        tokens = tokenizer.tokenize(text)
+        token_count = len(tokens)
+        max_context = model.max_context
+        usage_ratio = token_count / max_context if max_context else None
+        overflow = max(token_count - max_context, 0) if max_context else 0
+
+        pricing_info = None
+        if model.pricing:
+            pricing_info = model.pricing.to_dict()
+            input_price = model.pricing.input_per_1k
+            if input_price:
+                pricing_info["estimated_input_cost"] = round((token_count / 1000) * input_price, 6)
+
+        return {
+            "model": model.to_dict(),
+            "token_count": token_count,
+            "tokens": tokens,
+            "max_context": max_context,
+            "usage_ratio": usage_ratio,
+            "overflow": overflow,
+            "pricing": pricing_info,
+        }

--- a/app/tokenizers/__init__.py
+++ b/app/tokenizers/__init__.py
@@ -1,0 +1,14 @@
+"""Tokenizer implementations for the LLM token counter."""
+
+from .base import TokenizerAdapter
+from .regex_tokenizer import RegexTokenizer
+from .simple_byte_tokenizer import ByteTokenizer
+from .registry import TokenizerRegistry, get_tokenizer_for_model
+
+__all__ = [
+    "TokenizerAdapter",
+    "RegexTokenizer",
+    "ByteTokenizer",
+    "TokenizerRegistry",
+    "get_tokenizer_for_model",
+]

--- a/app/tokenizers/base.py
+++ b/app/tokenizers/base.py
@@ -1,0 +1,25 @@
+"""Base classes for tokenizer adapters."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Sequence
+
+
+class TokenizerAdapter(ABC):
+    """Common API for model-specific tokenizers."""
+
+    def __init__(self, name: str):
+        self.name = name
+
+    @abstractmethod
+    def tokenize(self, text: str) -> Sequence[object]:
+        """Split *text* into a sequence of tokens."""
+
+    def count_tokens(self, text: str) -> int:
+        """Return the number of tokens emitted for *text*."""
+
+        return len(self.tokenize(text))
+
+    def __repr__(self) -> str:  # pragma: no cover - debug helper
+        return f"{self.__class__.__name__}(name={self.name!r})"

--- a/app/tokenizers/regex_tokenizer.py
+++ b/app/tokenizers/regex_tokenizer.py
@@ -1,0 +1,56 @@
+"""Tokenizer implementation using configurable regular expressions."""
+
+from __future__ import annotations
+
+import re
+from typing import List, Sequence
+
+from .base import TokenizerAdapter
+
+_DEFAULT_PATTERN = (
+    r"[\u4e00-\u9fff]"  # CJK Unified Ideographs
+    r"|[\u3040-\u30ff]"  # Japanese Hiragana/Katakana
+    r"|[\uac00-\ud7af]"  # Hangul syllables
+    r"|[A-Za-z]+(?:'[A-Za-z]+)?"  # latin words with optional apostrophes
+    r"|[0-9]+"  # numbers
+    r"|_+"  # underscores sequences
+    r"|[^\w\s]"  # punctuation and symbols
+    r"|[\s]+"  # whitespace chunks
+)
+
+
+class RegexTokenizer(TokenizerAdapter):
+    """A configurable tokenizer powered by regular expressions."""
+
+    def __init__(
+        self,
+        name: str,
+        pattern: str | None = None,
+        normalize_lowercase: bool = False,
+        keep_whitespace: bool = False,
+        collapse_whitespace: bool = False,
+    ) -> None:
+        super().__init__(name=name)
+        self._normalize_lowercase = normalize_lowercase
+        self._keep_whitespace = keep_whitespace
+        self._collapse_whitespace = collapse_whitespace
+        self._pattern = re.compile(pattern or _DEFAULT_PATTERN, re.UNICODE)
+
+    def tokenize(self, text: str) -> Sequence[str]:
+        if not text:
+            return []
+        if self._normalize_lowercase:
+            text = text.lower()
+
+        raw_tokens: List[str] = []
+        for match in self._pattern.finditer(text):
+            token = match.group(0)
+            if not self._keep_whitespace and token.isspace():
+                continue
+            if self._collapse_whitespace and token.isspace():
+                if raw_tokens and raw_tokens[-1] == "<ws>":
+                    continue
+                raw_tokens.append("<ws>")
+            else:
+                raw_tokens.append(token)
+        return raw_tokens

--- a/app/tokenizers/registry.py
+++ b/app/tokenizers/registry.py
@@ -1,0 +1,58 @@
+"""Tokenizer registry and factory helpers."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from ..models import ModelSpec, TokenizerSpec
+from .base import TokenizerAdapter
+from .regex_tokenizer import RegexTokenizer
+
+
+class UnknownTokenizerError(ValueError):
+    """Raised when an unknown tokenizer type is requested."""
+
+
+class TokenizerRegistry:
+    """Factory responsible for building tokenizers from specifications."""
+
+    def __init__(self) -> None:
+        self._cache: Dict[str, TokenizerAdapter] = {}
+
+    def get_tokenizer(self, spec: TokenizerSpec, cache_key: str | None = None) -> TokenizerAdapter:
+        """Return a tokenizer instance for *spec* (cached by *cache_key* if given)."""
+
+        key = cache_key or f"{spec.type}:{hash(frozenset(spec.options.items()))}"
+        if key in self._cache:
+            return self._cache[key]
+
+        tokenizer = self._create_tokenizer(spec)
+        self._cache[key] = tokenizer
+        return tokenizer
+
+    def _create_tokenizer(self, spec: TokenizerSpec) -> TokenizerAdapter:
+        type_name = spec.type.lower()
+        options = dict(spec.options)
+        name = options.pop("name", type_name)
+
+        if type_name == "regex":
+            return RegexTokenizer(name=name, **options)
+        if type_name == "byte":
+            from .simple_byte_tokenizer import ByteTokenizer
+
+            return ByteTokenizer(name=name)
+        raise UnknownTokenizerError(f"Unknown tokenizer type: {spec.type}")
+
+    def invalidate(self, cache_key: str | None = None) -> None:
+        """Remove cached tokenizers."""
+
+        if cache_key is None:
+            self._cache.clear()
+        else:
+            self._cache.pop(cache_key, None)
+
+
+def get_tokenizer_for_model(model: ModelSpec, registry: TokenizerRegistry) -> TokenizerAdapter:
+    """Convenience helper returning the tokenizer for *model*."""
+
+    return registry.get_tokenizer(model.tokenizer, cache_key=model.model_id)

--- a/app/tokenizers/simple_byte_tokenizer.py
+++ b/app/tokenizers/simple_byte_tokenizer.py
@@ -1,0 +1,19 @@
+"""Simple tokenizer that counts raw UTF-8 bytes."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from .base import TokenizerAdapter
+
+
+class ByteTokenizer(TokenizerAdapter):
+    """Tokenizer that treats each UTF-8 byte as an individual token."""
+
+    def __init__(self, name: str = "byte-tokenizer") -> None:
+        super().__init__(name=name)
+
+    def tokenize(self, text: str) -> Sequence[int]:
+        if not text:
+            return []
+        return list(text.encode("utf-8"))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,37 @@
+import io
+import json
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+import app.__main__ as cli
+
+
+class CliTests(unittest.TestCase):
+    def test_cli_count(self):
+        with io.StringIO() as buffer:
+            with redirect_stdout(buffer):
+                exit_code = cli.main([
+                    "--registry",
+                    str(Path(__file__).resolve().parents[1] / "app" / "resources" / "model_registry.json"),
+                    "count",
+                    "--model",
+                    "gpt-4o-mini",
+                    "--text",
+                    "Hello world",
+                ])
+            self.assertEqual(exit_code, 0)
+            payload = json.loads(buffer.getvalue())
+            self.assertEqual(payload["model"]["id"], "gpt-4o-mini")
+
+    def test_cli_models_lists_entries(self):
+        with io.StringIO() as buffer:
+            with redirect_stdout(buffer):
+                cli.main(["models"])
+            payload = json.loads(buffer.getvalue())
+            self.assertIn("models", payload)
+            self.assertTrue(any(model["id"] == "qwen-2-7b" for model in payload["models"]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_token_service.py
+++ b/tests/test_token_service.py
@@ -1,0 +1,32 @@
+import unittest
+
+from app.config import load_registry
+from app.services.token_service import TokenService
+from app.tokenizers.registry import TokenizerRegistry
+
+
+class TokenServiceTests(unittest.TestCase):
+    def setUp(self):
+        models = load_registry()
+        registry = TokenizerRegistry()
+        self.service = TokenService(models=models, registry=registry)
+
+    def test_list_models_contains_expected_ids(self):
+        model_ids = {entry["id"] for entry in self.service.list_models()}
+        self.assertTrue({"gpt-4o-mini", "deepseek-chat", "qwen-2-7b"}.issubset(model_ids))
+
+    def test_calculate_returns_usage_and_cost_fields(self):
+        result = self.service.calculate("gpt-4o-mini", "Token counting test")
+        self.assertGreater(result["token_count"], 0)
+        self.assertEqual(result["max_context"], 128000)
+        self.assertEqual(result["usage_ratio"], result["token_count"] / 128000)
+        self.assertGreaterEqual(result["pricing"]["estimated_input_cost"], 0)
+
+    def test_calculate_handles_whitespace_model(self):
+        result = self.service.calculate("deepseek-chat", "Hello\n\nworld")
+        self.assertIn("<ws>", result["tokens"])
+        self.assertEqual(result["token_count"], len(result["tokens"]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tokenizers.py
+++ b/tests/test_tokenizers.py
@@ -1,0 +1,32 @@
+import unittest
+
+from app.tokenizers.regex_tokenizer import RegexTokenizer
+
+
+class RegexTokenizerTests(unittest.TestCase):
+    def test_basic_tokenization(self):
+        tokenizer = RegexTokenizer(name="test", keep_whitespace=False)
+        tokens = tokenizer.tokenize("Hello, 世界! 123\nNew line.")
+        self.assertEqual(
+            tokens,
+            [
+                "Hello",
+                ",",
+                "世",
+                "界",
+                "!",
+                "123",
+                "New",
+                "line",
+                ".",
+            ],
+        )
+
+    def test_tokenizer_with_whitespace(self):
+        tokenizer = RegexTokenizer(name="test", keep_whitespace=True, collapse_whitespace=True)
+        tokens = tokenizer.tokenize("Hi  there\n")
+        self.assertEqual(tokens, ["Hi", "<ws>", "there", "<ws>"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add configurable tokenizer adapters and registry using only the Python standard library
- implement token counting service, CLI commands, and a lightweight HTTP API for model listings and calculations
- document usage instructions and provide a default registry covering GPT, DeepSeek, and Qwen families

## Testing
- python -m unittest discover -s tests

------
https://chatgpt.com/codex/tasks/task_b_68d0eb98691c8325a91b464b19395b11